### PR TITLE
对引用文献样式文件的路径进行清理 Clear file path for citation style file

### DIFF
--- a/GUET-Thesis.cls
+++ b/GUET-Thesis.cls
@@ -1237,11 +1237,11 @@
   }{
     \setlength{\labelsep}{3pt}
     \renewcommand{\bstlabelmark}{loo}
-    \bibliographystyle{./References/GUET-Thesis(base-gbt7714-numerical).bst} % 插入参考文献的样式.bst文件
+    \bibliographystyle{References/GUET-Thesis(base-gbt7714-numerical)} % 插入参考文献的样式.bst文件
     \bibliography{#2}
     \setlength{\labelsep}{6pt}
   }{
-    \bibliographystyle{./References/GUET-Thesis(base-gbt7714-numerical).bst} % 插入参考文献的样式.bst文件
+    \bibliographystyle{References/GUET-Thesis(base-gbt7714-numerical)} % 插入参考文献的样式.bst文件
     \bibliography{#2} % 参考文献格式，用于指定排版参考文献所使用的文献格式文件名.bib
   }
 }


### PR DESCRIPTION
清理了引用文献样式文件的文件路径，解决在编译时有可能找不到样式文件的问题。
Clear file path for citation style file,prevent style file unfound error when compile